### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+os:
+  - linux
+  - osx
+
+language: minimal
+dist: trusty
+sudo: false
+osx_image: xcode10.1
+
+env:
+  - SWIFT_VERSION=4.2
+
+install:
+  - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+script:
+  - swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 
 import PackageDescription
 
@@ -16,5 +16,6 @@ let package = Package(
         .testTarget(
             name: "RationsTests",
             dependencies: ["Rations"]),
-    ]
+    ],
+    swiftLanguageVersions: [.v4_2]
 )

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Rations does have a performance penalty compared to Swift’s native floating po
 
 ## Install
 
+Rations requires Swift 4.2 or higher. It supports iOS, macOS, tvOS, watchOS, and Linux.
+
 ### Swift Package Manager
 
 Add the following line to your `Package.swift`:

--- a/Rations.podspec
+++ b/Rations.podspec
@@ -17,6 +17,7 @@ not approximations, are desired.
   s.source           = { git: 'https://github.com/Erik Strottmann/Rations.git', tag: s.version.to_s }
   s.social_media_url = 'https://twitter.com/erikstrottmann'
 
+  s.swift_version = '4.2'
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'


### PR DESCRIPTION
Also explicitly lists Swift 4.2 as a requirement, as revealed by CI. Rations uses conditional conformance, introduced in Swift 4.1, so it cannot compile in Swift 4.0.